### PR TITLE
fixed wrong screen shot caption on the welcome page

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -185,7 +185,7 @@
 									<span class="portfolio-inner" >
 										<span class="zoom-inner">
 											<span class="overlay title">Quick Match Entry</span>
-											<span class="overlay-tag">Arena</span>
+											<span class="overlay-tag">Constructed</span>
 										</span>
 									</span>
 								</div>


### PR DESCRIPTION
The first screen shot was incorrectly labeled “Arena”.
