### PR TITLE
Fixed 500 errors in matches API with null values

### DIFF
--- a/app/controllers/api/v1/matches_controller.rb
+++ b/app/controllers/api/v1/matches_controller.rb
@@ -50,7 +50,7 @@ module Api
         end
 
         if errors.count > 0
-          render json: {status: "fail", message: errors.join(" ")}
+          render json: {status: "fail", message: "MATCH NOT RECORDED. Errors detected: " + errors.join(" ")}
         else
 
           #create the match


### PR DESCRIPTION
I probably should have done this as a hotfix branch or something. I haven't had time to read the workflow link you sent me yet, but I wanted to get this fixes ASAP. I'll read-up on the proper branching methods soon.
