### PR TITLE
fixed rss feed images (fixes #175)

### DIFF
--- a/app/assets/stylesheets/pages/news.css
+++ b/app/assets/stylesheets/pages/news.css
@@ -73,10 +73,9 @@ News Page
   text-decoration: none;
 }
 
-.news-blocks img.news-block-img {
-  width: 70px;
-  height: 70px;
-  margin: 5px 0px 0 10px;
+.news-blocks img {
+    max-width: 100%;
+    height: auto;
 }
 
 .news-blocks .news-block-tags {


### PR DESCRIPTION
not sure what img.news-block-img was for, as that's unused in your views (maybe it used to exist at some point?), but setting max-width: 100% and auto-scaling the height will keep images from being too large for their div
