### PR TITLE
fixes #174 - use page caching instead of fragment caching

### DIFF
--- a/app/controllers/additional_controller.rb
+++ b/app/controllers/additional_controller.rb
@@ -1,5 +1,7 @@
 class AdditionalController < ApplicationController
 
+  caches_page :news, :expires_in => 1.day
+
   def contactus
   end
 
@@ -27,7 +29,7 @@ class AdditionalController < ApplicationController
   end
 
   def serverupgrade
-  	render :layout=>false
+  	render :layout => false
   end
 
   def news

--- a/app/views/additional/news.html.erb
+++ b/app/views/additional/news.html.erb
@@ -1,36 +1,34 @@
-<!-- <script src="http://masonry.desandro.com/js/masonry-docs.min.js"></script> -->
 <% set_meta_tags :title => 'Hearthstone News',
   :description => 'Latest Hearthstone News',
   :keywords => 'latest hearthstone, hearthstats, hearthstone, match, tracking, win, loss' %>
 <% provide(:title, 'Hearthstone News') %>
 <% provide(:subtitle, ' the latest in Hearthstone news') %>
 
-<% cache("news", :expires_in => 1.day) do %>
-	<div class="row">
-		<div class="col-md-12">
-			<small>Suggestions for news sources are welcome</small>
-		</div>
-		<div class="col-md-12 news-page">
-			<!-- entry array: title, url, summary, published -->
-			<div class="gridsizer"></div>
-			<% @items.each do |entry| %>
-			<div class="news-blocks rssentry">
-				<h3><a href=<%=entry[1]%> target="_blank" > <%= entry[0] %></a></h3>
-				<div class="news-block-tags">
-					<strong>Posted:</strong>
-					<em><%= entry[3].strftime("%b-%d-%Y") %></em>
-				</div>
-				<div class="rss_divider"></div>
-				<p><%= raw truncate(entry[2], :length => 500)  %></p>
-				<a href=<%=entry[1]%> class="news-block-btn" target="_blank" >
-				Read more
-				<i class="m-icon-swapright m-icon-black"></i>
-				</a>
-			</div>
-			<% end %>
-		</div>
-	</div>
-<% end %>
+<div class="row">
+  <div class="col-md-12">
+    <small>Suggestions for news sources are welcome</small>
+  </div>
+  <div class="col-md-12 news-page">
+    <!-- entry array: title, url, summary, published -->
+    <div class="gridsizer"></div>
+    <% @items.each do |entry| %>
+    <div class="news-blocks rssentry">
+      <h3><a href=<%=entry[1]%> target="_blank" > <%= entry[0] %></a></h3>
+      <div class="news-block-tags">
+        <strong>Posted:</strong>
+        <em><%= entry[3].strftime("%b-%d-%Y") %></em>
+      </div>
+      <div class="rss_divider"></div>
+      <p><%= raw truncate(entry[2], :length => 500)  %></p>
+      <a href=<%=entry[1]%> class="news-block-btn" target="_blank" >
+      Read more
+      <i class="m-icon-swapright m-icon-black"></i>
+      </a>
+    </div>
+    <% end %>
+  </div>
+</div>
+
 <script>
 	$('.news-page').isotope({
 	  // options


### PR DESCRIPTION
Caching a view fragment here isn't particularly helpful - the controller action still fetches the RSS feeds every time. From what I understand, fragment caching would more appropriate for caching database/ajax/whatever requests made in the view (and there aren't really any this case).

Anyways, this'll just save the entire generated /news page on the server and expire it daily, skipping the controller action entirely. If the page is particularly popular, you may want to set :race_condition_ttl to avoid a race condition when it expires.
