### PR TITLE
Ignore exception when a new user is already subscribed to a newsletter

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -7,13 +7,16 @@ class RegistrationsController < Devise::RegistrationsController
     destroy_guest
     super
 
-    c = Cindy.new "http://sendy.hearthstats.net", "cGF9DlbzfS0jBooMv5N3"
     if resource.save
       # Create Profile
       Profile.new(user_id:resource.id).save
 
-      c.subscribe "aQOe0RrtTXddPhL9p28929MA", resource.email
-      c.subscribe "6V763uDbDJuEja62CUwTlthQ", resource.email
+      begin
+        c = Cindy.new "http://sendy.hearthstats.net", "cGF9DlbzfS0jBooMv5N3"
+        c.subscribe "aQOe0RrtTXddPhL9p28929MA", resource.email
+        c.subscribe "6V763uDbDJuEja62CUwTlthQ", resource.email
+      rescue Cindy::AlreadySubscribed => e
+      end
     end
 
   end


### PR DESCRIPTION
Hi, I noticed a spec was failing because adding a subscriber to sendy.hearthstats.net would fail if the user's email was already subscribed. This ignores that exception so a user wouldn't be bothered by it and the specs can run without any issues.
