### PR TITLE
rename the session helper to match the filename

### DIFF
--- a/spec/support/integrations.rb
+++ b/spec/support/integrations.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include SessionHelpers
+  config.include SessionsHelper
 end

--- a/spec/support/integrations/sessions_helper.rb
+++ b/spec/support/integrations/sessions_helper.rb
@@ -1,4 +1,4 @@
-module SessionHelpers
+module SessionsHelper
   def sign_up_with(email, password)
     visit new_user_registration_path
     fill_in 'user_email', with: email


### PR DESCRIPTION
Travis is failing because it cant find the helper, this is because the file name is not matching the module name.
I'm not saying the specs will pass when this is fixed, but it's a step in the right direction :)
