### PR TITLE
Fix the specs

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe 'home page' do
+  before do
+    Rails.cache.write('wel#arena_top', [])
+    Rails.cache.write('wel#con_top', [])
+  end
+
+  after do
+    Rails.cache.delete('wel#arena_top')
+    Rails.cache.delete('wel#con_top')
+  end
+
   it 'should load' do
     visit '/'
     page.status_code.should be 200


### PR DESCRIPTION
The home page raises an error when the arena_top or con_top caches are empty, this should make the specs green.

The proper way would probably to fix the home page to handle empty caches but I'm not sure what kind of server the site runs on and if empty caches are ever a possibility.
