### PR TITLE
Refactor and add test coverage to CreateNewMatchesJob (formerly MultiMatchCreateJob)

### DIFF
--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -99,7 +99,9 @@ class Api::V3::MatchesController < ApplicationController
     rescue ActiveRecord::RecordNotFound => e
       render json: {status: 400, message: e.message} and return
     end
-    Delayed::Job.enqueue MatchJobs::CreateNewMatchesJob.new(_req[:matches], deck, current_user.id)
+
+    matches_params = _req[:matches].map(&:symbolize_keys)
+    Delayed::Job.enqueue MatchJobs::CreateNewMatchesJob.new(matches_params, deck, current_user.id)
     render json: {status: 200}
   end
 

--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -268,7 +268,7 @@ MultiMatchCreateJob = Struct.new(:_matches_params, :deck, :user_id) do
     match_rank_sql = []
     current_time = Time.now.to_s(:db)
     (initial_id..last_id).each_with_index do |match_id, i|
-      match_rank_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
+      match_deck_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
       # MatchDeck.create(match_id: match_id, deck_id: deck.id)
       if _matches_params[i][:mode] == "Ranked"
         match_rank_sql << "(#{match_id}, #{_matches_params[i]["ranklvl"].to_i || 'NULL'}, '#{current_time}', '#{current_time}')"

--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -93,15 +93,13 @@ class Api::V3::MatchesController < ApplicationController
   end
 
   def multi_create
-    _req = @req
     begin
-      deck = Deck.find(_req[:deck_id])
+      deck = Deck.find(@req[:deck_id])
     rescue ActiveRecord::RecordNotFound => e
       render json: {status: 400, message: e.message} and return
     end
 
-    matches_params = _req[:matches].map(&:symbolize_keys)
-    Delayed::Job.enqueue MatchJobs::CreateNewMatchesJob.new(matches_params, deck, current_user.id)
+    Delayed::Job.enqueue MatchJobs::CreateNewMatchesJob.new(@req[:matches].map(&:symbolize_keys), deck, current_user.id)
     render json: {status: 200}
   end
 

--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -262,7 +262,7 @@ MultiMatchCreateJob = Struct.new(:_matches_params, :deck, :user_id) do
       new_matches << parse_match_sql(_match_params, deck.klass_id, user_id)
     end
     sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches.join(",")}"
-    initial_id = Match.last.id
+    initial_id = Match.last ? Match.last.id : 1
     last_id =  ActiveRecord::Base.connection.insert sql_statement
     match_deck_sql = []
     match_rank_sql = []

--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -99,7 +99,7 @@ class Api::V3::MatchesController < ApplicationController
     rescue ActiveRecord::RecordNotFound => e
       render json: {status: 400, message: e.message} and return
     end
-    Delayed::Job.enqueue MultiMatchCreateJob.new(_req[:matches], deck, current_user.id)
+    Delayed::Job.enqueue MatchJobs::CreateNewMatchesJob.new(_req[:matches], deck, current_user.id)
     render json: {status: 200}
   end
 
@@ -250,54 +250,5 @@ class Api::V3::MatchesController < ApplicationController
     end
 
     match
-  end
-end
-
-MultiMatchCreateJob = Struct.new(:_matches_params, :deck, :user_id) do
-  def perform
-    new_matches = []
-    response = []
-    user_id = deck.user_id if user_id.nil?
-    _matches_params.each do |_match_params|
-      new_matches << parse_match_sql(_match_params, deck.klass_id, user_id)
-    end
-    sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches.join(",")}"
-    initial_id = Match.last ? Match.last.id : 1
-    last_id =  ActiveRecord::Base.connection.insert sql_statement
-    match_deck_sql = []
-    match_rank_sql = []
-    current_time = Time.now.to_s(:db)
-    (initial_id..last_id).each_with_index do |match_id, i|
-      match_deck_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
-      # MatchDeck.create(match_id: match_id, deck_id: deck.id)
-      if _matches_params[i]['mode'] == "Ranked"
-        match_rank_sql << "(#{match_id}, #{_matches_params[i]["ranklvl"].to_i || 'NULL'}, '#{current_time}', '#{current_time}')"
-        # MatchRank.create(match_id: match_id, rank_id: _req[:match][i]["ranklvl"].to_i)
-      end
-    end
-    deck_statement = "INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`,`updated_at`) VALUES #{match_deck_sql.join(",")}"
-    rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`,`updated_at`) VALUES #{match_rank_sql.join(",")}"
-    ActiveRecord::Base.connection.insert deck_statement if !match_deck_sql.empty?
-    ActiveRecord::Base.connection.insert rank_statement if !match_rank_sql.empty?
-  end
-
-  def parse_match_sql(_params, klass_id, user_id)
-    _params = _params.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
-    # Parse params to get variables
-    mode     = Mode::LIST.invert[_params[:mode]] || 'NULL'
-    oppclass = Klass::LIST.invert[_params[:oppclass]] || 'NULL'
-    result   = Match::RESULTS_LIST.invert[_params[:result]] || 'NULL'
-    coin     = _params[:coin] == "true"
-    match_str = "(#{user_id},#{mode},#{klass_id},#{result},#{coin},#{oppclass},'#{_params[:oppname] || 'NULL'}',#{_params[:numturns] || 'NULL'},#{_params[:duration] || 'NULL'},'#{_params[:notes] || 'NULL'}',true,'#{Time.now.to_s(:db)}','#{Time.now.to_s(:db)}')"
-
-    match_str
-  end
-
-  def max_run_time
-    120 # seconds
-  end
-
-  def queue_name
-    'multcreate_queue'
   end
 end

--- a/app/controllers/api/v3/matches_controller.rb
+++ b/app/controllers/api/v3/matches_controller.rb
@@ -270,7 +270,7 @@ MultiMatchCreateJob = Struct.new(:_matches_params, :deck, :user_id) do
     (initial_id..last_id).each_with_index do |match_id, i|
       match_deck_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
       # MatchDeck.create(match_id: match_id, deck_id: deck.id)
-      if _matches_params[i][:mode] == "Ranked"
+      if _matches_params[i]['mode'] == "Ranked"
         match_rank_sql << "(#{match_id}, #{_matches_params[i]["ranklvl"].to_i || 'NULL'}, '#{current_time}', '#{current_time}')"
         # MatchRank.create(match_id: match_id, rank_id: _req[:match][i]["ranklvl"].to_i)
       end

--- a/app/jobs/matches/create_new_matches_job.rb
+++ b/app/jobs/matches/create_new_matches_job.rb
@@ -1,22 +1,21 @@
 module MatchJobs
   CreateNewMatchesJob = Struct.new(:matches_params, :deck, :user_id) do
     def perform
-      match_insert_sql = Match.generate_mass_insert_sql(matches_params, deck.klass_id, user_id)
       initial_id = Match.last ? Match.last.id : 0
-      ActiveRecord::Base.connection.insert match_insert_sql
+      Match.connection.insert Match.generate_mass_insert_sql(matches_params, deck.klass_id, user_id)
 
       matches_params.each_with_index do |match_params, i|
         match_params[:id] = initial_id + i + 1
       end
 
-      match_deck_sql = MatchDeck.generate_mass_insert_sql(matches_params, deck.id)
+      MatchDeck.connection.insert MatchDeck.generate_mass_insert_sql(matches_params, deck.id)
+
       ranked_params = matches_params.select do |match_params|
         match_params[:mode] == "Ranked" && match_params[:ranklvl]
       end
-      match_rank_sql = MatchRank.generate_mass_insert_sql(ranked_params)
-
-      ActiveRecord::Base.connection.insert match_deck_sql
-      ActiveRecord::Base.connection.insert match_rank_sql unless ranked_params.empty?
+      unless ranked_params.empty?
+        MatchRank.connection.insert MatchRank.generate_mass_insert_sql(ranked_params)
+      end
     end
 
     def max_run_time

--- a/app/jobs/matches/create_new_matches_job.rb
+++ b/app/jobs/matches/create_new_matches_job.rb
@@ -1,0 +1,50 @@
+module MatchJobs
+  CreateNewMatchesJob = Struct.new(:matches_params, :deck, :user_id) do
+    def perform
+      new_matches = []
+      response = []
+      user_id = deck.user_id if user_id.nil?
+      matches_params.each do |match_params|
+        new_matches << parse_match_sql(match_params, deck.klass_id, user_id)
+      end
+      sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches.join(",")}"
+      initial_id = Match.last ? Match.last.id : 1
+      last_id =  ActiveRecord::Base.connection.insert sql_statement
+      match_deck_sql = []
+      match_rank_sql = []
+      current_time = Time.now.to_s(:db)
+      (initial_id..last_id).each_with_index do |match_id, i|
+        match_deck_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
+        # MatchDeck.create(match_id: match_id, deck_id: deck.id)
+        if matches_params[i]['mode'] == "Ranked"
+          match_rank_sql << "(#{match_id}, #{matches_params[i]["ranklvl"].to_i || 'NULL'}, '#{current_time}', '#{current_time}')"
+          # MatchRank.create(match_id: match_id, rank_id: _req[:match][i]["ranklvl"].to_i)
+        end
+      end
+      deck_statement = "INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`,`updated_at`) VALUES #{match_deck_sql.join(",")}"
+      rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`,`updated_at`) VALUES #{match_rank_sql.join(",")}"
+      ActiveRecord::Base.connection.insert deck_statement if !match_deck_sql.empty?
+      ActiveRecord::Base.connection.insert rank_statement if !match_rank_sql.empty?
+    end
+
+    def parse_match_sql(_params, klass_id, user_id)
+      _params = _params.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+      # Parse params to get variables
+      mode     = Mode::LIST.invert[_params[:mode]] || 'NULL'
+      oppclass = Klass::LIST.invert[_params[:oppclass]] || 'NULL'
+      result   = Match::RESULTS_LIST.invert[_params[:result]] || 'NULL'
+      coin     = _params[:coin] == "true"
+      match_str = "(#{user_id},#{mode},#{klass_id},#{result},#{coin},#{oppclass},'#{_params[:oppname] || 'NULL'}',#{_params[:numturns] || 'NULL'},#{_params[:duration] || 'NULL'},'#{_params[:notes] || 'NULL'}',true,'#{Time.now.to_s(:db)}','#{Time.now.to_s(:db)}')"
+
+      match_str
+    end
+
+    def max_run_time
+      120 # seconds
+    end
+
+    def queue_name
+      'multcreate_queue'
+    end
+  end
+end

--- a/app/jobs/matches/create_new_matches_job.rb
+++ b/app/jobs/matches/create_new_matches_job.rb
@@ -1,40 +1,39 @@
 module MatchJobs
   CreateNewMatchesJob = Struct.new(:matches_params, :deck, :user_id) do
     def perform
-      new_matches = []
-      response = []
-      user_id = deck.user_id if user_id.nil?
-      matches_params.each do |match_params|
-        new_matches << parse_match_sql(match_params, deck.klass_id, user_id)
+      current_time = Time.now.to_s(:db)
+      new_matches_sql = matches_params.map do |match_params|
+        match_params.symbolize_keys!
+        parse_match_sql(match_params, deck.klass_id, user_id, current_time)
       end
-      sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches.join(",")}"
+
+      sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches_sql.join(",")}"
       initial_id = Match.last ? Match.last.id : 1
       last_id =  ActiveRecord::Base.connection.insert sql_statement
+
       match_deck_sql = []
       match_rank_sql = []
       current_time = Time.now.to_s(:db)
       (initial_id..last_id).each_with_index do |match_id, i|
-        match_deck_sql << "(#{match_id}, #{deck.id},'#{current_time}', '#{current_time}')"
-        # MatchDeck.create(match_id: match_id, deck_id: deck.id)
-        if matches_params[i]['mode'] == "Ranked"
-          match_rank_sql << "(#{match_id}, #{matches_params[i]["ranklvl"].to_i || 'NULL'}, '#{current_time}', '#{current_time}')"
-          # MatchRank.create(match_id: match_id, rank_id: _req[:match][i]["ranklvl"].to_i)
+        match_deck_sql << "(#{match_id}, #{deck.id}, '#{current_time}', '#{current_time}')"
+
+        match_params = matches_params[i]
+        if match_params[:mode] == "Ranked"
+          match_rank_sql << "(#{match_id}, #{match_params["ranklvl"].to_i || "NULL"}, '#{current_time}', '#{current_time}')"
         end
       end
-      deck_statement = "INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`,`updated_at`) VALUES #{match_deck_sql.join(",")}"
-      rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`,`updated_at`) VALUES #{match_rank_sql.join(",")}"
+      deck_statement = "INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`, `updated_at`) VALUES #{match_deck_sql.join(",")}"
+      rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`, `updated_at`) VALUES #{match_rank_sql.join(",")}"
       ActiveRecord::Base.connection.insert deck_statement if !match_deck_sql.empty?
       ActiveRecord::Base.connection.insert rank_statement if !match_rank_sql.empty?
     end
 
-    def parse_match_sql(_params, klass_id, user_id)
-      _params = _params.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
-      # Parse params to get variables
-      mode     = Mode::LIST.invert[_params[:mode]] || 'NULL'
-      oppclass = Klass::LIST.invert[_params[:oppclass]] || 'NULL'
-      result   = Match::RESULTS_LIST.invert[_params[:result]] || 'NULL'
-      coin     = _params[:coin] == "true"
-      match_str = "(#{user_id},#{mode},#{klass_id},#{result},#{coin},#{oppclass},'#{_params[:oppname] || 'NULL'}',#{_params[:numturns] || 'NULL'},#{_params[:duration] || 'NULL'},'#{_params[:notes] || 'NULL'}',true,'#{Time.now.to_s(:db)}','#{Time.now.to_s(:db)}')"
+    def parse_match_sql(params, klass_id, user_id, current_time)
+      mode     = Mode::LIST.invert[params[:mode]]
+      oppclass = Klass::LIST.invert[params[:oppclass]]
+      result   = Match::RESULTS_LIST.invert[params[:result]]
+      coin     = params[:coin] == "true"
+      match_str = "(#{user_id},#{mode},#{klass_id},#{result},#{coin},#{oppclass},'#{params[:oppname] || 'NULL'}',#{params[:numturns] || 'NULL'},#{params[:duration] || 'NULL'},'#{params[:notes] || 'NULL'}',true,'#{current_time}','#{current_time}')"
 
       match_str
     end
@@ -44,7 +43,7 @@ module MatchJobs
     end
 
     def queue_name
-      'multcreate_queue'
+      'multicreate_queue'
     end
   end
 end

--- a/app/jobs/matches/create_new_matches_job.rb
+++ b/app/jobs/matches/create_new_matches_job.rb
@@ -2,24 +2,21 @@ module MatchJobs
   CreateNewMatchesJob = Struct.new(:matches_params, :deck, :user_id) do
     def perform
       match_insert_sql = Match.generate_mass_insert_sql(matches_params, deck.klass_id, user_id)
-      initial_id = Match.last ? Match.last.id : 1
-      last_id =  ActiveRecord::Base.connection.insert match_insert_sql
+      initial_id = Match.last ? Match.last.id : 0
+      ActiveRecord::Base.connection.insert match_insert_sql
 
-      match_deck_sql = []
-      match_rank_sql = []
-      current_time = Time.now.to_s(:db)
-      (initial_id..last_id).each_with_index do |match_id, i|
-        match_deck_sql << "(#{match_id}, #{deck.id}, '#{current_time}', '#{current_time}')"
-
-        match_params = matches_params[i]
-        if match_params[:mode] == "Ranked"
-          match_rank_sql << "(#{match_id}, #{match_params["ranklvl"].to_i || "NULL"}, '#{current_time}', '#{current_time}')"
-        end
+      matches_params.each_with_index do |match_params, i|
+        match_params[:id] = initial_id + i + 1
       end
-      deck_statement = "INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`, `updated_at`) VALUES #{match_deck_sql.join(",")}"
-      rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`, `updated_at`) VALUES #{match_rank_sql.join(",")}"
-      ActiveRecord::Base.connection.insert deck_statement if !match_deck_sql.empty?
-      ActiveRecord::Base.connection.insert rank_statement if !match_rank_sql.empty?
+
+      match_deck_sql = MatchDeck.generate_mass_insert_sql(matches_params, deck.id)
+      ranked_params = matches_params.select do |match_params|
+        match_params[:mode] == "Ranked" && match_params[:ranklvl]
+      end
+      match_rank_sql = MatchRank.generate_mass_insert_sql(ranked_params)
+
+      ActiveRecord::Base.connection.insert match_deck_sql
+      ActiveRecord::Base.connection.insert match_rank_sql unless ranked_params.empty?
     end
 
     def max_run_time

--- a/app/jobs/matches/create_new_matches_job.rb
+++ b/app/jobs/matches/create_new_matches_job.rb
@@ -1,15 +1,9 @@
 module MatchJobs
   CreateNewMatchesJob = Struct.new(:matches_params, :deck, :user_id) do
     def perform
-      current_time = Time.now.to_s(:db)
-      new_matches_sql = matches_params.map do |match_params|
-        match_params.symbolize_keys!
-        parse_match_sql(match_params, deck.klass_id, user_id, current_time)
-      end
-
-      sql_statement = "INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`) VALUES #{new_matches_sql.join(",")}"
+      match_insert_sql = Match.generate_mass_insert_sql(matches_params, deck.klass_id, user_id)
       initial_id = Match.last ? Match.last.id : 1
-      last_id =  ActiveRecord::Base.connection.insert sql_statement
+      last_id =  ActiveRecord::Base.connection.insert match_insert_sql
 
       match_deck_sql = []
       match_rank_sql = []
@@ -26,16 +20,6 @@ module MatchJobs
       rank_statement = "INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`, `updated_at`) VALUES #{match_rank_sql.join(",")}"
       ActiveRecord::Base.connection.insert deck_statement if !match_deck_sql.empty?
       ActiveRecord::Base.connection.insert rank_statement if !match_rank_sql.empty?
-    end
-
-    def parse_match_sql(params, klass_id, user_id, current_time)
-      mode     = Mode::LIST.invert[params[:mode]]
-      oppclass = Klass::LIST.invert[params[:oppclass]]
-      result   = Match::RESULTS_LIST.invert[params[:result]]
-      coin     = params[:coin] == "true"
-      match_str = "(#{user_id},#{mode},#{klass_id},#{result},#{coin},#{oppclass},'#{params[:oppname] || 'NULL'}',#{params[:numturns] || 'NULL'},#{params[:duration] || 'NULL'},'#{params[:notes] || 'NULL'}',true,'#{current_time}','#{current_time}')"
-
-      match_str
     end
 
     def max_run_time

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -311,7 +311,6 @@ class Match < ActiveRecord::Base
   def self.generate_mass_insert_sql(matches_params, klass_id, user_id)
     current_time = Time.now.to_s(:db)
     new_matches_sql = matches_params.map do |match_params|
-      match_params.symbolize_keys!
       self.generate_match_sql(match_params, klass_id, user_id, current_time)
     end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -120,7 +120,7 @@ class Match < ActiveRecord::Base
     klass_wr = Array.new
     match_count = Array.new
     Rank.all.each do |rank|
-      matches = rank.matches.where(klass_id: klass_id, 
+      matches = rank.matches.where(klass_id: klass_id,
                                    created_at: beginning..endday)
       id = rank.id
       if rank.id == 26
@@ -308,6 +308,20 @@ class Match < ActiveRecord::Base
     rank_klass
   end
 
+  def self.generate_mass_insert_sql(matches_params, klass_id, user_id)
+    current_time = Time.now.to_s(:db)
+    new_matches_sql = matches_params.map do |match_params|
+      match_params.symbolize_keys!
+      self.generate_match_sql(match_params, klass_id, user_id, current_time)
+    end
+
+    return <<-SQL
+INSERT INTO matches (`user_id`, `mode_id`, `klass_id`, `result_id`, `coin`, `oppclass_id`, `oppname`, `numturns`, `duration`, `notes`, `appsubmit`, `created_at`, `updated_at`)
+VALUES #{new_matches_sql.join(",")}
+    SQL
+  end
+
+
   ### INSTANCE METHODS:
 
   def archtype_id
@@ -350,6 +364,20 @@ class Match < ActiveRecord::Base
     unless deck.nil?
       deck.update_user_stats!
     end
+  end
+
+
+  protected
+  def self.generate_match_sql(params, klass_id, user_id, current_time)
+    mode_id = Mode::LIST.invert[params[:mode]]
+    oppclass_id = Klass::LIST.invert[params[:oppclass]]
+    result_id = Match::RESULTS_LIST.invert[params[:result]]
+    coin = params[:coin] == "true"
+
+    match_str = self.sanitize_sql_array(['(?,?,?,?,?,?,?,?,?,?,?,?,?)',
+      user_id, mode_id, klass_id, result_id, coin, oppclass_id, params[:oppname], params[:numturns], params[:duration], params[:notes], true, current_time, current_time
+    ])
+    match_str
   end
 
 end

--- a/app/models/match_deck.rb
+++ b/app/models/match_deck.rb
@@ -11,6 +11,20 @@ class MatchDeck < ActiveRecord::Base
   # before_save :set_unique_deck_and_version
   after_create :update_deck_user_stats
 
+
+  def self.generate_mass_insert_sql(matches_params, deck_id)
+    current_time = Time.now.to_s(:db)
+    new_match_decks_sql = matches_params.map do |match_params|
+      self.sanitize_sql_array(['(?,?,?,?)',
+        match_params[:id], deck_id, current_time, current_time])
+    end
+
+    return <<-SQL
+INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`, `updated_at`)
+VALUES #{new_match_decks_sql.join(",")}
+    SQL
+  end
+
   ### INSTANCE METHODS:
 
   def set_unique_deck_and_version
@@ -24,5 +38,5 @@ class MatchDeck < ActiveRecord::Base
     #update personal stats
     deck.update_user_stats!
   end
-  
+
 end

--- a/app/models/match_rank.rb
+++ b/app/models/match_rank.rb
@@ -6,4 +6,18 @@ class MatchRank < ActiveRecord::Base
   belongs_to :rank
   belongs_to :match
 
+
+  def self.generate_mass_insert_sql(matches_params)
+    current_time = Time.now.to_s(:db)
+    new_match_decks_sql = matches_params.map do |match_params|
+      self.sanitize_sql_array(['(?,?,?,?)',
+        match_params[:id], match_params[:ranklvl].to_i, current_time, current_time])
+    end
+
+    return <<-SQL
+INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`, `updated_at`)
+VALUES #{new_match_decks_sql.join(",")}
+    SQL
+  end
+
 end

--- a/spec/controllers/api/v3/matches_controller.rb
+++ b/spec/controllers/api/v3/matches_controller.rb
@@ -63,5 +63,11 @@ JSON
 
       expect(first_match_deck.deck).to eq(deck)
     end
+
+    it 'only creates match_rank assoications for Ranked mode matches' do
+      first_match, second_match = Match.last(2)
+      expect(MatchRank.count).to eq(1)
+      expect(MatchRank.last.match).to eq(first_match)
+    end
   end
 end

--- a/spec/controllers/api/v3/matches_controller.rb
+++ b/spec/controllers/api/v3/matches_controller.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Api::V3::MatchesController do
+  let(:user) { create(:user) }
+  before(:each) do
+    sign_in user
+  end
+
+  describe '#multi_create' do
+
+    let(:json_request) do
+<<-JSON
+{
+  "deck_id": "#{deck.id}",
+  "matches": [
+    {
+      "mode": "Ranked",
+      "ranklvl": 2,
+      "oppclass": "Priest",
+      "result": "Loss",
+      "coin": true,
+      "oppname": "StrifeCro",
+      "numturns": 26,
+      "duration": 85,
+      "notes": "CroFist!"
+    },
+    {
+      "mode": "Casual",
+      "oppclass": "Shaman",
+      "result": "Win",
+      "coin": false,
+      "oppname": "Trump",
+      "numturns": 13
+    }
+  ]
+}
+JSON
+    end
+
+    let(:deck) { create(:deck, name: 'Handlock', klass_id: 8, user_id: user.id) }
+
+    before(:each) do
+      @request.env['RAW_POST_DATA'] = json_request
+      post :multi_create
+      Delayed::Worker.new.run(Delayed::Job.last)
+    end
+
+    it '(eventually) adds new matches to the database' do
+      first_match, second_match = Match.last(2)
+      expect(first_match.mode_id).to eq(3)
+      expect(first_match.oppname).to eq('StrifeCro')
+
+      expect(second_match.result_id).to eq(1)
+      expect(second_match.coin).to be(false)
+    end
+  end
+end

--- a/spec/controllers/api/v3/matches_controller.rb
+++ b/spec/controllers/api/v3/matches_controller.rb
@@ -53,5 +53,15 @@ JSON
       expect(second_match.result_id).to eq(1)
       expect(second_match.coin).to be(false)
     end
+
+    it 'creates a match_deck association object for each new match' do
+      first_match, second_match = Match.last(2)
+      first_match_deck, second_match_deck = MatchDeck.last(2)
+
+      expect(first_match.match_deck).to eq(first_match_deck)
+      expect(second_match.match_deck).to eq(second_match_deck)
+
+      expect(first_match_deck.deck).to eq(deck)
+    end
   end
 end

--- a/spec/models/match_deck_spec.rb
+++ b/spec/models/match_deck_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe MatchDeck do
+  describe '::generate_mass_insert_sql' do
+    let(:matches_params) { [{id: 1}, {id: 2}] }
+
+    let(:deck_id) { 5 }
+    let!(:time_now) { Time.now }
+    let(:db_time) { time_now.to_s(:db) }
+
+    before(:each) do
+      Time.stub(:now).and_return(time_now)
+    end
+
+    it 'generates a mass insert sql string' do
+      insert_sql = MatchDeck.generate_mass_insert_sql(matches_params, deck_id)
+      expect(insert_sql).to eq(<<-SQL)
+INSERT INTO match_decks (`match_id`, `deck_id`, `created_at`, `updated_at`)
+VALUES (1,5,'#{db_time}','#{db_time}'),(2,5,'#{db_time}','#{db_time}')
+      SQL
+    end
+  end
+end

--- a/spec/models/match_rank_spec.rb
+++ b/spec/models/match_rank_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe MatchRank do
+  describe '::generate_mass_insert_sql' do
+    let(:matches_params) do
+      [{
+        id: 1,
+        ranklvl: "2"
+      }]
+    end
+
+    let!(:time_now) { Time.now }
+    let(:db_time) { time_now.to_s(:db) }
+
+    before(:each) do
+      Time.stub(:now).and_return(time_now)
+    end
+
+    it 'generates a mass insert sql string' do
+      insert_sql = MatchRank.generate_mass_insert_sql(matches_params)
+      expect(insert_sql).to eq(<<-SQL)
+INSERT INTO match_ranks (`match_id`, `rank_id`, `created_at`, `updated_at`)
+VALUES (1,2,'#{db_time}','#{db_time}')
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
Hi, HS!

In this PR, I added test coverage to and refactored the MultiMatchCreate Delayed Job queued by the v3 JSON api `/match/multi_create` route.

I also fixed a few bugs ([match_decks were being created as match_ranks](https://github.com/crawsible/hearthstats/commit/bf393b8cf5b80eb09c4329debd63dfcc22e20b00), and [no match_ranks were being generated](https://github.com/crawsible/hearthstats/commit/1d4607a1fc91f0b4b618da32016d3a48ef88f216), and addressed a security issue.

It seems to me that at least some of the troubles from #501 were the result of the Delayed Job failing (I'm guessing you're not throwing out failed DJs) due to one or another of these bugs, so I'm pretty sure this PR will help resolve future malformed Delayed Jobs.

There's definitely more work to be done around this API flow though. For example, I don't think it's wise to assume that [batch-inserted rows will definitely have sequential ids](https://github.com/crawsible/hearthstats/blob/75c8907966923db1adfec7020b317b5803b2aabb/app/jobs/matches/create_new_matches_job.rb#L8).

In the meantime, this should stanch the bleeding somewhat, and future DJs generated from this API path should be much less likely to fail. Hope this helps!

-csj