### PR TITLE
No duplicate matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ local.properties
 database.yml
 console
 
+# jetbrains specific git ignore
+.idea/*
+
 # Ignore application configuration
 /config/application.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
   gem 'seed_dump', :require => false
   gem 'awesome_print', :require => false
   gem 'active_record_query_trace'
-  gem "thin"
+  gem 'thin'
 end
 
 group :assets do
@@ -86,7 +86,7 @@ gem 'groupdate'
 gem 'announcements'
 gem 'rmagick'
 # gem 'rack-ssl-enforcer'
-gem "squeel"
+gem 'squeel'
 gem 'pusher'
 gem 'sync'
 gem 'react-rails', '~> 1.0'
@@ -107,11 +107,11 @@ gem 'delayed_job_web'
 gem 'daemons'
 gem 'whenever'
 
-gem "puma"
+gem 'puma'
 gem 'dotenv-rails'
   
 platforms :mri do
-  gem "skylight"
+  gem 'skylight'
 end
 
 group :test do

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -393,16 +393,14 @@ VALUES #{new_matches_sql.join(",")}
   end
 
   def ==(match)
-    self.oppname == match.oppname && self.duration == match.duration
+    match && self.oppname == match.oppname && self.duration == match.duration
   end
 
   ### VALIDATION METHODS:
 
   def no_duplicate_matches
-    user = User.find(self.user_id)
-    unless user.matches.last != self
-      errors.add(:match, 'This is a duplicate of the last match')
-    end
+    last_user_match = Match.where(user_id: self.user_id).last
+    errors.add(:match, 'This is a duplicate of the last match') unless self != last_user_match
   end
 
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -75,6 +75,8 @@ class Match < ActiveRecord::Base
   validates_presence_of :oppclass_id
   validates_presence_of :klass_id
 
+  validate :no_duplicate_matches
+
   ### CALLBACKS:
 
   before_save :set_season_patch
@@ -387,6 +389,19 @@ VALUES #{new_matches_sql.join(",")}
   def update_user_stats_constructed
     unless deck.nil?
       deck.update_user_stats!(self)
+    end
+  end
+
+  def ==(match)
+    self.oppname == match.oppname && self.duration == match.duration
+  end
+
+  ### VALIDATION METHODS:
+
+  def no_duplicate_matches
+    user = User.find(self.user_id)
+    unless user.matches.last != self
+      errors.add(:match, 'This is a duplicate of the last match')
     end
   end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -1,7 +1,18 @@
 require 'spec_helper'
 
 describe Match do
-  describe "class methods" do
+  describe 'custom validations' do
+    it 'should not allow creation of duplicate matches' do
+      match_params = {klass_id: 1, result_id: 2, mode_id: 3, user_id: 4 }
+      match = Match.create(match_params)
+      expect(match).to be_valid
+
+      duplicate_match = Match.new(match_params)
+      expect(duplicate_match).to_not be_valid
+    end
+  end
+
+  describe 'class methods' do
     describe '::bestuserarena' do
       let(:user) { build :user }
 
@@ -11,7 +22,7 @@ describe Match do
         create :match, klass_id: 2, result_id: 1, mode_id: 1, user: user
         create :match, klass_id: 1, result_id: 2, mode_id: 1, user_id: 666
 
-        Match.bestuserarena(user.id).should == ["Druid", 100]
+        Match.bestuserarena(user.id).should == ['Druid', 100]
       end
     end
 
@@ -31,14 +42,14 @@ describe Match do
 
     describe '::matches_per_class' do
       it 'inits all classes to 0' do
-        Match.matches_per_class.should == { "Druid"=>0, "Hunter"=>0, "Mage"=>0, "Paladin"=>0, "Priest"=>0, "Rogue"=>0, "Shaman"=>0, "Warlock"=>0, "Warrior"=>0 }
+        Match.matches_per_class.should == { 'Druid'=>0, 'Hunter'=>0, 'Mage'=>0, 'Paladin'=>0, 'Priest'=>0, 'Rogue'=>0, 'Shaman'=>0, 'Warlock'=>0, 'Warrior'=>0 }
       end
 
       it 'returns the number of played matches per class' do
         create :match, klass_id: 1
         create :match, klass_id: 3
 
-        Match.matches_per_class.should == { "Druid"=>1, "Hunter"=>0, "Mage"=>1, "Paladin"=>0, "Priest"=>0, "Rogue"=>0, "Shaman"=>0, "Warlock"=>0, "Warrior"=>0 }
+        Match.matches_per_class.should == { 'Druid'=>1, 'Hunter'=>0, 'Mage'=>1, 'Paladin'=>0, 'Priest'=>0, 'Rogue'=>0, 'Shaman'=>0, 'Warlock'=>0, 'Warrior'=>0 }
       end
     end
 
@@ -52,7 +63,7 @@ describe Match do
         win   = create :match, klass: klass, result_id: 1
         loss  = create :match, klass: klass, result_id: 0
 
-        Match.top_winrates_with_class.should == [["Druid", 50.0], 0, 0, 0, 0, 0, 0, 0, 0]
+        Match.top_winrates_with_class.should == [['Druid', 50.0], 0, 0, 0, 0, 0, 0, 0, 0]
       end
     end
 
@@ -79,8 +90,8 @@ describe Match do
         it 'generates and executes a match mass-insert sql command' do
           Match.should_receive(:generate_mass_insert_sql)
             .with(matches_params, 7, 5)
-            .and_return("INSERT luck INTO forsen")
-          Match.connection.should_receive(:insert).with("INSERT luck INTO forsen")
+            .and_return('INSERT luck INTO forsen')
+          Match.connection.should_receive(:insert).with('INSERT luck INTO forsen')
 
           Match.mass_import_new_matches(matches_params, deck_id, deck_klass_id, user_id)
         end
@@ -98,19 +109,19 @@ describe Match do
         it 'generates and executes a MatchDeck mass-insert sql command' do
           MatchDeck.should_receive(:generate_mass_insert_sql)
             .with(matches_params, 13)
-            .and_return("INSERT drboom INTO turn7")
-          MatchDeck.connection.should_receive(:insert).with("INSERT drboom INTO turn7")
+            .and_return('INSERT drboom INTO turn7')
+          MatchDeck.connection.should_receive(:insert).with('INSERT drboom INTO turn7')
           Match.mass_import_new_matches(matches_params, deck_id, deck_klass_id, user_id)
         end
 
         it 'generates and executes a MatchRank mass-insert sql command' do
-          ranked_match.should_receive(:[]).with(:mode).and_return("Ranked")
-          ranked_match.should_receive(:[]).with(:ranklvl).and_return("1")
+          ranked_match.should_receive(:[]).with(:mode).and_return('Ranked')
+          ranked_match.should_receive(:[]).with(:ranklvl).and_return('1')
 
           MatchRank.should_receive(:generate_mass_insert_sql)
             .with([ranked_match])
-            .and_return("INSERT value INTO valuetown")
-          MatchRank.connection.should_receive(:insert).with("INSERT value INTO valuetown")
+            .and_return('INSERT value INTO valuetown')
+          MatchRank.connection.should_receive(:insert).with('INSERT value INTO valuetown')
           Match.mass_import_new_matches(matches_params, deck_id, deck_klass_id, user_id)
         end
       end
@@ -118,15 +129,15 @@ describe Match do
       describe '::generate_mass_insert_sql' do
         let(:matches_params) do
           [{
-            mode: "Ranked",
-            oppclass: "Priest",
-            result: "Win",
-            coin: "false"
+            mode: 'Ranked',
+            oppclass: 'Priest',
+            result: 'Win',
+            coin: 'false'
           }, {
-            mode: "Arena",
-            oppclass: "Warlock",
-            result: "Loss",
-            coin: "true"
+            mode: 'Arena',
+            oppclass: 'Warlock',
+            result: 'Loss',
+            coin: 'true'
           }]
         end
 
@@ -150,10 +161,10 @@ VALUES (1,3,3,1,0,5,NULL,NULL,NULL,NULL,1,'#{db_time}','#{db_time}'),(1,1,3,2,1,
         context 'when fending off sneaky pranksters' do
           let(:matches_params) do
             [{
-              mode: "Ranked",
-              oppclass: "Priest",
-              result: "Win",
-              coin: "false",
+              mode: 'Ranked',
+              oppclass: 'Priest',
+              result: 'Win',
+              coin: 'false',
               notes: "ripperino trumpW',NULL,NULL);DROP TABLE users"
             }]
           end


### PR DESCRIPTION
I noticed that my HS Tracker would create many duplicate matches, and I would have to manually delete them. This will stop the creation of duplicate matches.

I COULD NOT GET HEARHTSTATS TO BUILD ON MY SYSTEM. Therefore, I was not actually able to test this, nor run the tests. I realize this is a big inconvenience for someone else to test, but I would greatly appreciate it. If this does not work, please tell me and I will update the code.

This pull request contains four things:

1) An `==` method for matches
2) A `no_duplicate_matches` validation for matches
3) A spec for the validation
4) Enforcing single/double quote styleguide rules as requested on the readme to gemfile, match.rb, and match_spec.rb

![](http://i.imgur.com/0sKSMgW.gif)